### PR TITLE
Fix: Correctly import auth middleware in chat routes

### DIFF
--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const chatController = require('../controller/chat');
-const { protect } = require('../middleware/auth'); // Assuming auth middleware is here
+const protect = require('../middleware/auth'); // Assuming auth middleware is here
 
 // POST /api/chat/room - Create a new chat room
 // For now, only authenticated users can create rooms.


### PR DESCRIPTION
The chat routes file (`backend/routes/chat.js`) was attempting to destructure `protect` from the imported auth middleware. However, the auth middleware exports the function directly.

This commit changes the import statement to assign the imported middleware function directly to `protect`, resolving the "Route.post() requires a callback function but got a [object Undefined]" error.