### PR TITLE
Improve recipe item navigation and handle missing recipe data

### DIFF
--- a/backend/models/recipe.js
+++ b/backend/models/recipe.js
@@ -26,4 +26,4 @@ const recipeSchema=mongoose.Schema({
 
 },{timestamps:true})
 
-module.exports=mongoose.model("Recipes",recipeSchema)
+module.exports = mongoose.model("Recipes", recipeSchema)

--- a/frontend/food-blog-app/src/components/RecipeItems.jsx
+++ b/frontend/food-blog-app/src/components/RecipeItems.jsx
@@ -9,12 +9,11 @@ import axios from 'axios';
 
 export default function RecipeItems() {
     const recipes = useLoaderData()
-    const [allRecipes, setAllRecipes] = useState()
+    const [allRecipes, setAllRecipes] = useState([])
     let path = window.location.pathname === "/myRecipe" ? true : false
     let favItems = JSON.parse(localStorage.getItem("fav")) ?? []
     const [isFavRecipe, setIsFavRecipe] = useState(false)
-    const navigate=useNavigate()
-    console.log(allRecipes)
+    const navigate = useNavigate()
 
     useEffect(() => {
         setAllRecipes(recipes)
@@ -39,9 +38,9 @@ export default function RecipeItems() {
         <>
             <div className='card-container'>
                 {
-                    allRecipes?.map((item, index) => {
+                    allRecipes.map((item, index) => {
                         return (
-                            <div key={index} className='card' onDoubleClick={()=>navigate(`/recipe/${item._id}`)}>
+                            <div key={index} className='card' onClick={() => navigate(`/recipe/${item._id}`)}>
                                 {item.coverImage ?
                                     <img src={item.coverImage} width="200px" height="160px" alt={item.title} /> :
                                     <img src={foodImg} width="200px" height="160px" alt="Default recipe image" />

--- a/frontend/food-blog-app/src/pages/RecipeDetails.jsx
+++ b/frontend/food-blog-app/src/pages/RecipeDetails.jsx
@@ -4,25 +4,45 @@ import food from '../assets/foodRecipe.png'
 import { useLoaderData } from 'react-router-dom'
 
 export default function RecipeDetails() {
-    const recipe=useLoaderData()
-    console.log(recipe)
-  return (
-   <>
-    <div className='outer-container'>
-        <div className='profile'>
-            <img src={profileImg} width="50px" height="50px"></img>
-            <h5>{recipe.email}</h5>
-        </div>
-        <h3 className='title'>{recipe.title}</h3>
-        {recipe.coverImage ?
-            <img src={recipe.coverImage} width="220px" height="200px" alt={recipe.title} /> :
-            <img src={food} width="220px" height="200px" alt="Default recipe image" />
-        }
-        <div className='recipe-details'>
-            <div className='ingredients'><h4>Ingredients</h4><ul>{recipe.ingredients.map((item, index)=>(<li key={index}>{item}</li>))}</ul></div>
-            <div className='instructions'><h4>Instructions</h4><p>{recipe.instructions}</p></div>
-        </div>
-    </div>
-   </>
-  )
+    const recipe = useLoaderData()
+
+    if (!recipe) {
+        return (
+            <div className='outer-container'>
+                <p>Recipe not found.</p>
+            </div>
+        )
+    }
+
+    const ingredients = Array.isArray(recipe.ingredients) ? recipe.ingredients : []
+
+    return (
+        <>
+            <div className='outer-container'>
+                <div className='profile'>
+                    <img src={profileImg} width="50px" height="50px" alt="profile" />
+                    <h5>{recipe.email}</h5>
+                </div>
+                <h3 className='title'>{recipe.title}</h3>
+                {recipe.coverImage ?
+                    <img src={recipe.coverImage} width="220px" height="200px" alt={recipe.title} /> :
+                    <img src={food} width="220px" height="200px" alt="Default recipe image" />
+                }
+                <div className='recipe-details'>
+                    <div className='ingredients'>
+                        <h4>Ingredients</h4>
+                        <ul>
+                            {ingredients.map((item, index) => (
+                                <li key={index}>{item}</li>
+                            ))}
+                        </ul>
+                    </div>
+                    <div className='instructions'>
+                        <h4>Instructions</h4>
+                        <p>{recipe.instructions}</p>
+                    </div>
+                </div>
+            </div>
+        </>
+    )
 }


### PR DESCRIPTION
## Summary
- Prevent RecipeDetails page from crashing when recipe data or ingredients are missing
- Open recipe details on single click and initialize recipe list state
- Clean up recipe model formatting

## Testing
- `cd backend && npm test`
- `cd ../frontend/food-blog-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee02fcf6883259685467dfd55145e